### PR TITLE
Upgrade dependencies (windows-sys and socket2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,5 @@ tokio = { version = "1.9.0", features = [
 ] }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.36", features = ["Win32_Foundation", "Win32_System_IO", "Win32_Networking_WinSock"] }
+windows-sys = { version = "0.48", features = ["Win32_Foundation", "Win32_System_IO", "Win32_Networking_WinSock"] }
 once_cell = "1.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0.3"
 log = "0.4"
 pin-project = "1.0"
 
-socket2 = { version = "0.4", features = ["all"] }
+socket2 = { version = "0.5.3", features = ["all"] }
 tokio = { version = "1.9.0", features = [
     "io-util",
     "macros",


### PR DESCRIPTION
I was trying to reduce the number of duplicate dependency versions in the dependency tree of our product. `windows-sys` stood out with four different versions. Version 0.36 was only used by a single dependency (this one). So I thought I'd send a PR to upgrade it. While doing so I saw that it was trivial to do the same with `socket2` as well.

As far as I can tell neither of these crates are part of the public API of `tokio-tfo`. So I hope this can be released as a patch release :)