### PR TITLE
Support to create TfoListener from std/tokio net TcpListener

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,7 +1,7 @@
 //! TFO stream
 
 #[cfg(unix)]
-use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::io::{AsRawFd, RawFd, AsFd, BorrowedFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, RawSocket};
 use std::{
@@ -124,6 +124,13 @@ impl From<TokioTcpStream> for TfoStream {
         TfoStream {
             inner: SysTcpStream::from(s),
         }
+    }
+}
+
+#[cfg(unix)]
+impl AsFd for TfoStream {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.inner.as_fd()
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,7 +1,7 @@
 //! TFO stream
 
 #[cfg(unix)]
-use std::os::unix::io::{AsRawFd, RawFd, AsFd, BorrowedFd};
+use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, RawSocket};
 use std::{

--- a/src/sys/unix/bsd/freebsd.rs
+++ b/src/sys/unix/bsd/freebsd.rs
@@ -1,8 +1,7 @@
 use std::{
-    io,
-    mem,
+    io, mem,
     net::{SocketAddr, TcpStream as StdTcpStream},
-    os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd},
+    os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd},
     pin::Pin,
     task::{self, Poll, Waker},
     time::Duration,
@@ -294,6 +293,16 @@ impl AsyncWrite for TcpStream {
         match self.project().stream.project() {
             TcpStreamOptionProj::Connected(stream) => stream.poll_shutdown(cx),
             _ => Ok(()).into(),
+        }
+    }
+}
+
+impl AsFd for TcpStream {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        match self.stream {
+            TcpStreamOption::Connected(ref s) => s.as_fd(),
+            TcpStreamOption::Connecting { ref socket, .. } => socket.as_fd(),
+            _ => unreachable!("stream connected without a TcpStream instance"),
         }
     }
 }

--- a/src/sys/unix/bsd/macos.rs
+++ b/src/sys/unix/bsd/macos.rs
@@ -3,7 +3,7 @@ use std::{
     mem,
     net::{SocketAddr, TcpStream as StdTcpStream},
     ops::{Deref, DerefMut},
-    os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd},
+    os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd},
     pin::Pin,
     ptr,
     task::{self, Poll},
@@ -198,6 +198,12 @@ impl AsyncWrite for TcpStream {
 
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
         self.project().inner.poll_shutdown(cx)
+    }
+}
+
+impl AsFd for TcpStream {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.inner.as_fd()
     }
 }
 

--- a/src/sys/unix/linux.rs
+++ b/src/sys/unix/linux.rs
@@ -2,7 +2,7 @@ use std::{
     io::{self, ErrorKind},
     mem,
     net::{SocketAddr, TcpStream as StdTcpStream},
-    os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd},
+    os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd},
     pin::Pin,
     sync::atomic::{AtomicBool, Ordering},
     task::{self, Poll, Waker},
@@ -371,6 +371,16 @@ impl AsyncWrite for TcpStream {
         match self.project().stream.project() {
             TcpStreamOptionProj::Connected(stream) => stream.poll_shutdown(cx),
             _ => Ok(()).into(),
+        }
+    }
+}
+
+impl AsFd for TcpStream {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        match self.stream {
+            TcpStreamOption::Connected(ref s) => s.as_fd(),
+            TcpStreamOption::Connecting { ref socket, .. } => socket.as_fd(),
+            _ => unreachable!("stream connected without a TcpStream instance"),
         }
     }
 }

--- a/tests/from_listener.rs
+++ b/tests/from_listener.rs
@@ -1,0 +1,57 @@
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpSocket,
+};
+use tokio_tfo::{TfoListener, TfoStream};
+
+#[tokio::test]
+async fn from_std() {
+    let server = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    // For TfoListener::from_std, there is no need to set it in advance.
+    // server.set_nonblocking(true).unwrap();
+
+    let server = TfoListener::from_std(server).unwrap();
+    test_echo(server).await;
+}
+
+#[tokio::test]
+async fn from_tokio() {
+    let server = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let server = TfoListener::from_tokio(server).unwrap();
+    test_echo(server).await;
+}
+
+async fn test_echo(server: TfoListener) {
+    let server_addr = server.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        loop {
+            let (mut stream, peer_addr) = server.accept().await.unwrap();
+            println!("accepted {}", peer_addr);
+
+            tokio::spawn(async move {
+                let mut buffer = [0u8; 4096];
+                loop {
+                    let n = stream.read(&mut buffer).await.unwrap();
+                    if n == 0 {
+                        break;
+                    }
+
+                    let _ = stream.write_all(&buffer[..n]).await;
+                }
+            });
+        }
+    });
+
+    const TEST_PAYLOAD: &[u8] = b"hello world";
+
+    let socket = TcpSocket::new_v4().unwrap();
+    socket.bind("127.0.0.1:0".parse().unwrap()).unwrap();
+
+    let mut client = TfoStream::connect_with_socket(socket, server_addr).await.unwrap();
+    client.write_all(TEST_PAYLOAD).await.unwrap();
+
+    let mut buffer = [0u8; 1024];
+    let n = client.read(&mut buffer).await.unwrap();
+    assert_eq!(&buffer[..n], TEST_PAYLOAD);
+}


### PR DESCRIPTION
This PR adds an API for creating TfoListener from std/tokio net TcpListener, also adds the AsFd trait for TfoStream.